### PR TITLE
Install binman on unix-like

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 notes.md
 *.obj
+*.o
 *.exe
 command_line/**
 *.swp
-obj/
-obj/*
 binman

--- a/inc/bin_print.h
+++ b/inc/bin_print.h
@@ -1,7 +1,7 @@
-#ifdef BIN_PRINT
+#ifndef BIN_PRINT
 
-
-#else
+/* Contains a macro to convert macro text to string */
+#include <stringize.h>
 
 #define BIN_PRINT
 
@@ -12,12 +12,21 @@
 #define DUMP 0
 #define WRITE 1
 
-// TODO: Improve ability to find help file, esp. when PATH is set
-#ifdef _MSC_VER
+
+
+
+#if defined INSTALL_ROOT
+#if defined _MSC_VER
+	 #define HELP_FILENAME STRINGIZE_MACRO(INSTALL_ROOT) "\\share\\binman\\help.txt"
+#else
+	 #define HELP_FILENAME STRINGIZE_MACRO(INSTALL_ROOT) "/share/binman/help.txt"
+#endif /* defined _MSC_VER */
+#elif defined _MSC_VER
 	#define HELP_FILENAME "doc\\windows_help.txt"
 #else
-	#define HELP_FILENAME "doc/unix_help.txt"
-#endif
+	#define HELP_FILENAME "./doc/unix_help.txt"
+#endif /* INSTALL_ROOT */
+
 
 /* Print functions */
 int bin_out(FILE *input, FILE *output, char type); // Chooses program flow

--- a/inc/stringize.h
+++ b/inc/stringize.h
@@ -1,0 +1,13 @@
+/*
+ * Utility to convert raw text to a string with the preprocessor. Used
+ * currently to convert the install file path to a string.
+ */
+
+#ifndef BIN_STRINGIZE
+#define BIN_STRINGIZE
+
+#define STRINGIZE( x ) #x
+#define STRINGIZE_MACRO( x ) STRINGIZE(x)
+
+
+#endif

--- a/src/bin_print.c
+++ b/src/bin_print.c
@@ -176,8 +176,10 @@ int print_help(void)
     int c;
     FILE *help;
 
+#ifdef DEBUG
     // Help file location defined in bin_print.h
     printf("Help filename: " HELP_FILENAME "\n");
+#endif /* DEBUG */
     if ((help = fopen(HELP_FILENAME, "r")) == NULL)
     {
         error_msg;

--- a/src/bin_print.c
+++ b/src/bin_print.c
@@ -177,6 +177,7 @@ int print_help(void)
     FILE *help;
 
     // Help file location defined in bin_print.h
+    printf("Help filename: " HELP_FILENAME "\n");
     if ((help = fopen(HELP_FILENAME, "r")) == NULL)
     {
         error_msg;

--- a/unix_makefile
+++ b/unix_makefile
@@ -3,7 +3,7 @@
 # 	:set expandtab?		=> noexpandtab
 
 ifndef INSTALL_ROOT
-INSTALL_ROOT := ./program
+INSTALL_ROOT := /usr/local
 endif
 
 
@@ -14,7 +14,7 @@ SRCDIR	:= src
 OBJDIR 	:= obj
 CC 		:= gcc -c
 LD		:= gcc -o
-CFLAGS	:= -I$(INCDIR) -Wall -g3 # Use incdir, all warnings, add debug info
+CFLAGS	:= -I$(INCDIR) -Wall -g3 -DINSTALL_ROOT='$(INSTALL_ROOT)'
 LDFLAGS	:= -g3
 
 
@@ -56,7 +56,7 @@ binman.o: binman.c bin_arg_parse.h bin_flow.h bin_error.h bin_print.h
 
 bin_ops.o: bin_ops.c bin_ops.h bin_print.h bin_error.h
 
-bin_print.o: bin_print.c bin_ops.h bin_print.h bin_error.h
+bin_print.o: bin_print.c bin_ops.h bin_print.h bin_error.h stringize.h
 
 .PHONY : clean # in case there is ever a file called 'clean'
 # remove object files, keep going if error
@@ -75,7 +75,6 @@ install:
 .PHONY : uninstall
 uninstall:
 	echo "Uninstalling binman from $(INSTALL_ROOT).."
-	mkdir -p $(INSTALL_ROOT)/{bin/binman,share/binman}
 	rm -f $(INSTALL_ROOT)/bin/binman
 	rm -rf $(INSTALL_ROOT)/share/binman/
 

--- a/unix_makefile
+++ b/unix_makefile
@@ -16,36 +16,37 @@ CC 		:= gcc -c
 LD		:= gcc -o
 CFLAGS	:= -I$(INCDIR) -Wall -g3 # Use incdir, all warnings, add debug info
 LDFLAGS	:= -g3
-SRCS	:= $(wildcard $(SRCDIR)/*.c)
-# OBJS	:= $(patsubst %.c, $(OBJDIR)/%.o, $(SRCS))
-OBJS	:= $(patsubst $(SRCDIR)/%.c, $(OBJDIR)/%.o, $(SRCS))
-
-# Header dependencies
-DEPS	:= $(wildcard $(INCDIR)/*.h)
 
 # Quickref
 # $^	prereq list
-# S@	target
-# S<	first prereq
-# S?	out of date dependencies
-# S+	all dependencies
+# $@	target
+# $<	first prereq
+# $?	out of date dependencies
+# $+	all dependencies
 # $|	'order only' prereqs
 
 all: $(TARGET) # Default rule runs when TARGET is out of date
 
-$(TARGET) : $(OBJS)
+$(TARGET) : $(OBJDIR)/bin_arg_parse.o $(OBJDIR)/bin_error.o $(OBJDIR)/bin_flow.o $(OBJDIR)/binman.o $(OBJDIR)/bin_ops.o $(OBJDIR)/bin_print.o
 	$(LD) $(LDFLAGS) -o $(TARGET) $^
 
-$(OBJDIR)/%.o : $(SRCDIR)/%.c $(DEPS)
-	$(CC) $(CFLAGS) -o $@ $<
+$(OBJDIR)/bin_arg_parse.o: $(SRCDIR)/bin_arg_parse.c $(INCDIR)/bin_arg_parse.h $(INCDIR)/bin_error.h
+	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_arg_parse.c
 
-$(OBJS): | $(OBJDIR) # Make objdir first, no out-of-date check
+$(OBJDIR)/bin_error.o: $(SRCDIR)/bin_error.c $(INCDIR)/bin_error.h
+	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_error.c
 
-$(OBJDIR): | $(OBJDIR)
-	mkdir $@
+$(OBJDIR)/bin_flow.o: $(SRCDIR)/bin_flow.c $(INCDIR)/bin_print.h $(INCDIR)/bin_ops.h $(INCDIR)/bin_arg_parse.h $(INCDIR)/bin_flow.h
+	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_flow.c
 
-$(OBJDIR):
-	mkdir $@
+$(OBJDIR)/binman.o: $(SRCDIR)/binman.c $(INCDIR)/bin_arg_parse.h $(INCDIR)/bin_flow.h $(INCDIR)/bin_error.h $(INCDIR)/bin_print.h
+	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/binman.c
+
+$(OBJDIR)/bin_ops.o: $(SRCDIR)/bin_ops.c $(INCDIR)/bin_ops.h $(INCDIR)/bin_print.h $(INCDIR)/bin_error.h
+	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_ops.c
+
+$(OBJDIR)/bin_print.o: $(SRCDIR)/bin_print.c $(INCDIR)/bin_ops.h $(INCDIR)/bin_print.h $(INCDIR)/bin_error.h
+	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_print.c
 
 .PHONY : clean # in case there is ever a file called 'clean'
 # remove object files, keep going if error
@@ -56,7 +57,19 @@ clean:
 .PHONY : install
 install:
 	echo "Installing into $(INSTALL_ROOT)..."
-	mkdir -p $(INSTALL_ROOT)/{bin,share/binman}
-	cp binman $(INSTALL_ROOT)/bin
-	cp doc/help.txt $(INSTALL_ROOT)/share
+	mkdir -p $(INSTALL_ROOT)/bin
+	mkdir -p $(INSTALL_ROOT)/share/binman
+	cp binman $(INSTALL_ROOT)/bin/binman
+	cp doc/help.txt $(INSTALL_ROOT)/share/binman/help.txt
+
+.PHONY : uninstall
+uninstall:
+	echo "Uninstalling binman from $(INSTALL_ROOT).."
+	mkdir -p $(INSTALL_ROOT)/{bin/binman,share/binman}
+	rm -f $(INSTALL_ROOT)/bin/binman
+	rm -rf $(INSTALL_ROOT)/share/binman/
+
+.PHONY : test
+test:
+	echo "$(OBJS)"
 

--- a/unix_makefile
+++ b/unix_makefile
@@ -2,6 +2,11 @@
 # Note: tabs not spaces. E.g. if in vim, check your tab expand:
 # 	:set expandtab?		=> noexpandtab
 
+ifndef INSTALL_ROOT
+INSTALL_ROOT := ./program
+endif
+
+
 TARGET  := binman  # Final target name
 
 INCDIR 	:= inc
@@ -48,4 +53,10 @@ clean:
 	-rm -f $(OBJDIR)/*.o
 	-rm -f binman
 
+.PHONY : install
+install:
+	echo "Installing into $(INSTALL_ROOT)..."
+	mkdir -p $(INSTALL_ROOT)/{bin,share/binman}
+	cp binman $(INSTALL_ROOT)/bin
+	cp doc/help.txt $(INSTALL_ROOT)/share
 

--- a/unix_makefile
+++ b/unix_makefile
@@ -17,6 +17,22 @@ LD		:= gcc -o
 CFLAGS	:= -I$(INCDIR) -Wall -g3 # Use incdir, all warnings, add debug info
 LDFLAGS	:= -g3
 
+
+
+
+# Overwrite implicit rule for object files
+# A little dangerous because it always uses the first prerequisite
+%.o: %.c
+	$(CC) $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+# Set up search paths for particular extensions
+vpath %.o $(OBJDIR):.
+
+vpath %.c $(SRCDIR):.
+
+vpath %.h $(INCDIR):.
+
+
 # Quickref
 # $^	prereq list
 # $@	target
@@ -27,26 +43,20 @@ LDFLAGS	:= -g3
 
 all: $(TARGET) # Default rule runs when TARGET is out of date
 
-$(TARGET) : $(OBJDIR)/bin_arg_parse.o $(OBJDIR)/bin_error.o $(OBJDIR)/bin_flow.o $(OBJDIR)/binman.o $(OBJDIR)/bin_ops.o $(OBJDIR)/bin_print.o
-	$(LD) $(LDFLAGS) -o $(TARGET) $^
+$(TARGET) : bin_arg_parse.o bin_error.o bin_flow.o binman.o bin_ops.o bin_print.o
+	$(LD) $(LDFLAGS) -o $@ $(OBJDIR)/*
 
-$(OBJDIR)/bin_arg_parse.o: $(SRCDIR)/bin_arg_parse.c $(INCDIR)/bin_arg_parse.h $(INCDIR)/bin_error.h
-	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_arg_parse.c
+bin_arg_parse.o: bin_arg_parse.c bin_arg_parse.h bin_error.h
 
-$(OBJDIR)/bin_error.o: $(SRCDIR)/bin_error.c $(INCDIR)/bin_error.h
-	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_error.c
+bin_error.o: bin_error.c bin_error.h
 
-$(OBJDIR)/bin_flow.o: $(SRCDIR)/bin_flow.c $(INCDIR)/bin_print.h $(INCDIR)/bin_ops.h $(INCDIR)/bin_arg_parse.h $(INCDIR)/bin_flow.h
-	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_flow.c
+bin_flow.o: bin_flow.c bin_print.h bin_ops.h bin_arg_parse.h bin_flow.h
 
-$(OBJDIR)/binman.o: $(SRCDIR)/binman.c $(INCDIR)/bin_arg_parse.h $(INCDIR)/bin_flow.h $(INCDIR)/bin_error.h $(INCDIR)/bin_print.h
-	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/binman.c
+binman.o: binman.c bin_arg_parse.h bin_flow.h bin_error.h bin_print.h
 
-$(OBJDIR)/bin_ops.o: $(SRCDIR)/bin_ops.c $(INCDIR)/bin_ops.h $(INCDIR)/bin_print.h $(INCDIR)/bin_error.h
-	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_ops.c
+bin_ops.o: bin_ops.c bin_ops.h bin_print.h bin_error.h
 
-$(OBJDIR)/bin_print.o: $(SRCDIR)/bin_print.c $(INCDIR)/bin_ops.h $(INCDIR)/bin_print.h $(INCDIR)/bin_error.h
-	$(CC) $(CFLAGS) -o $@ $(SRCDIR)/bin_print.c
+bin_print.o: bin_print.c bin_ops.h bin_print.h bin_error.h
 
 .PHONY : clean # in case there is ever a file called 'clean'
 # remove object files, keep going if error


### PR DESCRIPTION
Includes basic changes to install binman on (a very limited set of) unix-like OSs. Tested on latest mac and debian 11.

Certainly not elegant, but I'm not far enough along in learning about autotools to add nice support like that. Really, this is just for me to experiment with the problem space of installing software.

To install in a custom location, set the `INSTALL_ROOT` environment variable. For example,

```
$ INSTALL_ROOT=/Users/charlie/programs make
$ INSTALL_ROOT=/Users/charlie/programs make install
```